### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1](https://github.com/orhun/flawz/compare/0.1.0-rc.1..0.1.1) - 2024-05-20
+
+### 🐛 Bug Fixes
+
+- Remove unused terminal tick event ([#12](https://github.com/orhun/flawz/pull/12)) - ([39da120](https://github.com/orhun/flawz/commit/39da120b09602bb81ab23e42d11fc01ac7fded25))
+
+### 📚 Documentation
+
+- Add Homebrew install instructions ([#14](https://github.com/orhun/flawz/pull/14)) - ([3871647](https://github.com/orhun/flawz/commit/3871647308d0185635e47df3d1850cfaa67200e1))
+- Link to the NetBSD package search page - ([557dfa1](https://github.com/orhun/flawz/commit/557dfa16fae3e02c5972a79bc7de6c8c028b3083))
+- Add NetBSD instructions ([#10](https://github.com/orhun/flawz/pull/10)) - ([d6c817c](https://github.com/orhun/flawz/commit/d6c817c00683ef5832760f8711b1f9e0aa7cdbe6))
+- Update documentation for event module - ([ec55a92](https://github.com/orhun/flawz/commit/ec55a929251621398288f1447c04a1b77770b768))
+
 ## [0.1.0-rc.1] - 2024-05-18
 
 ### 📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -282,7 +282,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -391,7 +391,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "flawz"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 4.5.4",
  "clap_complete",
@@ -1068,7 +1068,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1164,9 +1164,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -1412,7 +1412,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1667,7 +1667,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1909,7 +1909,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -1943,7 +1943,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2161,5 +2161,5 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flawz"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Terminal UI for browsing CVEs"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `flawz`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/orhun/flawz/compare/0.1.0-rc.1..0.1.1) - 2024-05-20

### 🐛 Bug Fixes

- Remove unused terminal tick event ([#12](https://github.com/orhun/flawz/pull/12)) - ([39da120](https://github.com/orhun/flawz/commit/39da120b09602bb81ab23e42d11fc01ac7fded25))

### 📚 Documentation

- Add Homebrew install instructions ([#14](https://github.com/orhun/flawz/pull/14)) - ([3871647](https://github.com/orhun/flawz/commit/3871647308d0185635e47df3d1850cfaa67200e1))
- Link to the NetBSD package search page - ([557dfa1](https://github.com/orhun/flawz/commit/557dfa16fae3e02c5972a79bc7de6c8c028b3083))
- Add NetBSD instructions ([#10](https://github.com/orhun/flawz/pull/10)) - ([d6c817c](https://github.com/orhun/flawz/commit/d6c817c00683ef5832760f8711b1f9e0aa7cdbe6))
- Update documentation for event module - ([ec55a92](https://github.com/orhun/flawz/commit/ec55a929251621398288f1447c04a1b77770b768))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).