### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/orhun/flawz/compare/0.1.1..0.1.2) - 2024-05-24
+
+### 🚀 Features
+
+- Support opening the first HTTP reference in browser ([#11](https://github.com/orhun/flawz/pull/11)) ([#15](https://github.com/orhun/flawz/pull/15)) - ([e970ebc](https://github.com/orhun/flawz/commit/e970ebc84ddf3016e2507cd74bedd88873972e03))
+
+### 📚 Documentation
+
+- Update key bindings table - ([41dea0c](https://github.com/orhun/flawz/commit/41dea0cc623de18b833d307d618b004074fcb055))
+- Add key bindings ([#20](https://github.com/orhun/flawz/pull/20)) - ([f8bcfa0](https://github.com/orhun/flawz/commit/f8bcfa023e22ac602f41f423075233fff7b3fa58))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update macos runner - ([39d240b](https://github.com/orhun/flawz/commit/39d240b2e5cb0b86fdcbd24c142ba10f0d4a914c))
+
 ## [0.1.1](https://github.com/orhun/flawz/compare/0.1.0-rc.1..0.1.1) - 2024-05-20
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.2](https://github.com/orhun/flawz/compare/0.1.1..0.1.2) - 2024-05-24
+## [0.2.0](https://github.com/orhun/flawz/compare/0.1.1..0.2.0) - 2024-05-24
 
 ### 🚀 Features
 
@@ -39,4 +39,3 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Update cargo-dist targets - ([d704fd9](https://github.com/orhun/flawz/commit/d704fd9c02297f7073e3d37e0deae6ce35c4dad1))
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "flawz"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "clap 4.5.4",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block2"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ff7d91d3c1d568065b06c899777d1e48dcf76103a672a0adbc238a7f247f1e"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
 ]
@@ -363,9 +363,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "flawz"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap 4.5.4",
  "clap_complete",
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1080,15 +1080,15 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
  "objc2-encode",
@@ -1096,17 +1096,19 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.1"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88658da63e4cc2c8adb1262902cd6af51094df0488b760d6fd27194269c0950a"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
+ "bitflags 2.5.0",
  "block2",
+ "libc",
  "objc2",
 ]
 
@@ -1640,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1815,7 +1817,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1836,7 +1837,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flawz"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Terminal UI for browsing CVEs"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flawz"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Terminal UI for browsing CVEs"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `flawz`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/orhun/flawz/compare/0.1.1..0.1.2) - 2024-05-24

### 🚀 Features

- Support opening the first HTTP reference in browser ([#11](https://github.com/orhun/flawz/pull/11)) ([#15](https://github.com/orhun/flawz/pull/15)) - ([e970ebc](https://github.com/orhun/flawz/commit/e970ebc84ddf3016e2507cd74bedd88873972e03))

### 📚 Documentation

- Update key bindings table - ([41dea0c](https://github.com/orhun/flawz/commit/41dea0cc623de18b833d307d618b004074fcb055))
- Add key bindings ([#20](https://github.com/orhun/flawz/pull/20)) - ([f8bcfa0](https://github.com/orhun/flawz/commit/f8bcfa023e22ac602f41f423075233fff7b3fa58))

### ⚙️ Miscellaneous Tasks

- Update macos runner - ([39d240b](https://github.com/orhun/flawz/commit/39d240b2e5cb0b86fdcbd24c142ba10f0d4a914c))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).