### PR TITLE
fix: fix the constraint for showing CVE ids (#24)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -115,7 +115,7 @@ fn render_list(app: &mut App, frame: &mut Frame<'_>, area: Rect) {
             Line::default()
         });
     frame.render_stateful_widget(
-        Table::new(items, &[Constraint::Min(13), Constraint::Percentage(100)])
+        Table::new(items, &[Constraint::Min(14), Constraint::Percentage(100)])
             .header(Row::new(vec![
                 "Name".set_style(app.theme.highlight).bold(),
                 "Description".set_style(app.theme.highlight).bold(),


### PR DESCRIPTION
## Description of change

Increased constraint to %14 from %13.

This PR closes the issue #24 when displaying long CVE names.

## How has this been tested?

You can manually test it with any of the CVE that follows `CVE-{4}-{5}` format.
It might be nice to test with different aspect ratios.

- [x] I tested with 1920x1080 (16:9) 

## Screenshots

Old(%13):

![20240602_18h38m04s_grim](https://github.com/orhun/flawz/assets/61623638/71a6eba5-62ba-4b35-bd73-34204415036d)

New(%14):

![20240602_18h37m52s_grim](https://github.com/orhun/flawz/assets/61623638/4660395a-1037-422f-a16e-0f73bf2d9949)
