### PR TITLE
docs(readme): details about SQLite dep and avoiding crates mismatch v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,17 @@ flawz --feeds 2024 --query xz
 **flawz** can be installed from [crates.io](https://crates.io/crates/flawz) using [`cargo`](https://doc.rust-lang.org/cargo/) if [Rust](https://www.rust-lang.org/tools/install) is installed.
 
 ```sh
-cargo install flawz
+cargo install --locked flawz
 ```
 
 The minimum supported Rust version (MSRV) is `1.74.1`.
+
+> [!NOTE]
+> You need to have SQLite 3 development files installed. On Debian and its derivates you can do so with the following command:
+>
+> ```sh
+> sudo apt install libsqlite3-dev
+> ```
 
 ### Arch Linux
 


### PR DESCRIPTION
## Description of change

Added details to avoid common pitfalls during install via `cargo`, such as missing SQLite C development files and installing without `--locked` option, which could lead to potential crate versions clash.

## How has this been tested? (if applicable)

Tested on my machine after chatting on issue #13 .
