### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/src/bin/mangen.rs
+++ b/src/bin/mangen.rs
@@ -19,7 +19,7 @@ const OUT_DIR_ENV: &str = "OUT_DIR";
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
     let out_dir = env::var(OUT_DIR_ENV).unwrap_or_else(|_| panic!("{OUT_DIR_ENV} is not set"));
-    let out_path = PathBuf::from(out_dir).join(format!("{}.1", env!("CARGO_PKG_NAME")));
+    let out_path = PathBuf::from(out_dir).join(concat!(env!("CARGO_PKG_NAME"), ".1"));
     let app = Args::command();
     let man = Man::new(app);
     let mut buffer = Vec::<u8>::new();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -155,10 +155,12 @@ fn highlight_search_result(value: String, app: &App) -> Line {
 
 fn render_header(app: &mut App, frame: &mut Frame<'_>, area: Rect) {
     let title = Paragraph::new(
-        format!(
-            " {} - {} ",
+        concat!(
+            " ",
             env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_DESCRIPTION")
+            " - ",
+            env!("CARGO_PKG_DESCRIPTION"),
+            " ",
         )
         .bold(),
     )
@@ -166,7 +168,7 @@ fn render_header(app: &mut App, frame: &mut Frame<'_>, area: Rect) {
     .alignment(Alignment::Left);
     frame.render_widget(title, area);
 
-    let text = format!("v{} with ♥ by @orhun ", env!("CARGO_PKG_VERSION"));
+    let text = concat!("v", env!("CARGO_PKG_VERSION"), " with ♥ by @orhun ");
     let meta = Paragraph::new(text)
         .block(Block::default().style(app.theme.header))
         .alignment(Alignment::Right);


### PR DESCRIPTION
<!--- Thank you for contributing to flawz! -->

## Description of change

- Replace format! with concat! for string literals

- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.

## How has this been tested? (if applicable)

`cargo test` passed,