### PR TITLE
feat: migrate to NVD 2.0 via nvd_cve 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,8 @@ dependencies = [
 [[package]]
 name = "nvd_cve"
 version = "0.3.0"
-source = "git+https://github.com/Aionmizu/nvd_cve?branch=nvd-api-2.0#63b174ec0d119ce27ecc614dfd2d799c947e8983"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380132d6059b12671dfd2824f8ad56b58b0d7838df9bbde48750a340ccfe99c"
 dependencies = [
  "chrono",
  "clap 2.34.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -116,12 +116,6 @@ dependencies = [
  "anstyle",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -229,6 +223,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -351,16 +351,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -374,15 +364,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossterm"
@@ -483,15 +464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,24 +515,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fastrand"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "flate2"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "flawz"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap 4.5.20",
  "clap_complete",
@@ -569,7 +525,7 @@ dependencies = [
  "nvd_cve",
  "ratatui",
  "textwrap 0.16.1",
- "thiserror",
+ "thiserror 1.0.66",
  "tui-input",
  "tui-popup",
  "webbrowser",
@@ -586,21 +542,6 @@ name = "foldhash"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -668,8 +609,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -677,25 +620,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "h2"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "hashbrown"
@@ -797,12 +721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
-name = "humansize"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +735,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -843,22 +760,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -920,16 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
-dependencies = [
- "equivalent",
- "hashbrown 0.15.0",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,7 +875,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.66",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1092,23 +984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,23 +1000,19 @@ dependencies = [
 
 [[package]]
 name = "nvd_cve"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e9000f1a03cbccc8a9bf97ab6062470a6f77f8e2615eee85717edcafe00fb"
+version = "0.3.0"
+source = "git+https://github.com/Aionmizu/nvd_cve?branch=nvd-api-2.0#63b174ec0d119ce27ecc614dfd2d799c947e8983"
 dependencies = [
  "chrono",
  "clap 2.34.0",
  "env_logger",
- "flate2",
  "home",
- "humansize",
  "log",
  "progress",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -1192,50 +1063,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "openssl"
-version = "0.10.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1291,6 +1118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.27",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,12 +1145,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1384,39 +1302,38 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -1462,6 +1379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1501,6 +1425,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1535,42 +1462,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -1756,40 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,7 +1696,16 @@ version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.66",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1843,6 +1713,17 @@ name = "thiserror-impl"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1880,16 +1761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,19 +1768,6 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -2166,13 +2024,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5f07fb9bc8de2ddfe6b24a71a75430673fd679e568c48b52716cef1cfae923"
 dependencies = [
  "block2",
- "core-foundation 0.10.0",
+ "core-foundation",
  "home",
  "jni",
  "log",
@@ -2181,6 +2049,24 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2407,7 +2293,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -2415,6 +2310,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "flawz-mangen"
 path = "src/bin/mangen.rs"
 
 [dependencies]
-nvd_cve = { version = "0.3.0", git = "https://github.com/Aionmizu/nvd_cve", branch = "nvd-api-2.0" }
+nvd_cve = "0.3.0"
 ratatui = "0.29.0"
 thiserror = "1.0.66"
 textwrap = "0.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flawz"
-version = "0.3.0"
+version = "0.4.0"
 description = "A Terminal UI for browsing CVEs"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "flawz-mangen"
 path = "src/bin/mangen.rs"
 
 [dependencies]
-nvd_cve = "0.2.0"
+nvd_cve = { version = "0.3.0", git = "https://github.com/Aionmizu/nvd_cve", branch = "nvd-api-2.0" }
 ratatui = "0.29.0"
 thiserror = "1.0.66"
 textwrap = "0.16.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 
-use crate::{app::AppResult, error::Error, theme::BuiltinTheme};
+use crate::theme::BuiltinTheme;
 
 /// Command line arguments.
 #[derive(Debug, Default, Parser)]
@@ -19,17 +19,15 @@ With ♥ by {author-with-newline}
 ",
 )]
 pub struct Args {
-    /// A URL where NIST CVE 1.1 feeds can be found.
-    #[arg(long, env, default_value = "https://nvd.nist.gov/feeds/json/cve/1.1/")]
-    pub url: String,
-
-    /// List of feeds that are going to be synced.
+    /// Feeds to sync. Accepts a year (`2024`), a year range (`2002:2024`),
+    /// `recent` (last 8 days of new publications) or `modified` (last 8
+    /// days of modifications). Multiple feeds can be given.
     #[arg(
         short,
         long,
         env,
         num_args(0..),
-        default_values_t = ["2002:2024".to_string(), "recent".into(), "modified".into()]
+        default_values_t = ["2002:2025".to_string(), "recent".into(), "modified".into()]
     )]
     pub feeds: Vec<String>,
 
@@ -37,11 +35,17 @@ pub struct Args {
     #[arg(short, env, long)]
     pub db: Option<String>,
 
-    /// Always fetch feeds.
+    /// NVD API key. With a key the rate limit is 50 requests / 30s
+    /// (instead of 5 / 30s), making sync roughly 10× faster. Get one at
+    /// <https://nvd.nist.gov/developers/request-an-api-key>.
+    #[arg(short = 'k', long, env = "NVD_API_KEY")]
+    pub api_key: Option<String>,
+
+    /// Re-sync feeds that are already present in the cache.
     #[arg(short = 'u', long)]
     pub force_update: bool,
 
-    /// Do not fetch feeds.
+    /// Do not fetch feeds — read only what is already cached.
     #[arg(short, long)]
     pub offline: bool,
 
@@ -52,35 +56,6 @@ pub struct Args {
     /// Set the theme.
     #[arg(short, long, value_enum, default_value = "dracula")]
     pub theme: BuiltinTheme,
-}
-
-impl Args {
-    /// Parses and returns the feeds.
-    pub fn feeds(&self) -> AppResult<Vec<String>> {
-        self.feeds
-            .iter()
-            .try_fold::<Vec<_>, _, AppResult<_>>(vec![], |mut acc, v| {
-                if v.contains(':') {
-                    let mut parts = v.split(':');
-                    let start = parts
-                        .next()
-                        .and_then(|v| v.parse::<usize>().ok())
-                        .ok_or_else(|| Error::RangeArgsError)?;
-                    let end = parts
-                        .next()
-                        .and_then(|v| v.parse::<usize>().ok())
-                        .ok_or_else(|| Error::RangeArgsError)?;
-                    acc.extend(
-                        (start..=end)
-                            .map(|v| v.to_string())
-                            .collect::<Vec<String>>(),
-                    );
-                } else {
-                    acc.push(v.clone())
-                }
-                Ok(acc)
-            })
-    }
 }
 
 #[cfg(test)]

--- a/src/cve.rs
+++ b/src/cve.rs
@@ -1,35 +1,41 @@
 use nvd_cve::cve::Cve as NvdCve;
 
-/// CVE.
+/// Flat, UI-friendly view of an NVD CVE record.
+///
+/// Built from [`nvd_cve::cve::Cve`] so the rest of the TUI does not need to
+/// know about the API's nested shape (descriptions per language, references
+/// with source/tags, multiple CVSS scoring systems).
 #[derive(Clone, Debug)]
 pub struct Cve {
-    /// ID.
+    /// CVE ID.
     pub id: String,
-    /// Description.
+    /// English description, when available.
     pub description: Option<String>,
-    /// Assigner.
+    /// Identifier of the CNA / source that submitted the record.
     pub assigner: String,
-    /// References.
+    /// External reference URLs, deduplicated upstream by NVD.
     pub references: Vec<String>,
+    /// Highest-precedence CVSS base score (`v4.0 → v3.1 → v3.0 → v2.0`).
+    pub base_score: Option<f32>,
+    /// Severity label matching `base_score` (`LOW`, `MEDIUM`, `HIGH`, `CRITICAL`).
+    pub severity: Option<String>,
+    /// `Analyzed`, `Modified`, `Rejected`, … (from NVD's `vulnStatus`).
+    pub status: String,
 }
 
 impl From<NvdCve> for Cve {
     fn from(cve: NvdCve) -> Self {
+        let description = cve.description_en().map(str::to_string);
+        let base_score = cve.base_score();
+        let severity = cve.severity().map(str::to_string);
         Self {
-            id: cve.cve_data_meta.id.to_string(),
-            description: cve
-                .description
-                .description_data
-                .iter()
-                .find(|desc| desc.lang == *"en")
-                .map(|v| v.value.to_string()),
-            assigner: cve.cve_data_meta.assigner.to_string(),
-            references: cve
-                .references
-                .reference_data
-                .iter()
-                .map(|v| v.url.to_string())
-                .collect(),
+            id: cve.id,
+            description,
+            assigner: cve.source_identifier,
+            references: cve.references.into_iter().map(|r| r.url).collect(),
+            base_score,
+            severity,
+            status: cve.vuln_status,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,9 +20,11 @@ pub enum Error {
     /// Error that may occur while parsing colors.
     #[error("Failed to parse color")]
     ParseColorError,
-    /// Error that can occur while parsing the arguments.
-    #[error("Invalid range given. Please use the format <start:end>")]
-    RangeArgsError,
+    /// Error that occurs while parsing a `--feeds` token (e.g. bad range
+    /// or unknown shortcut). The inner message comes from
+    /// `nvd_cve::feed::FeedError`.
+    #[error("Failed to parse --feeds token: {0}")]
+    FeedParseError(String),
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,27 +13,33 @@ use std::path::Path;
 use std::{io, thread};
 
 use nvd_cve::cache::{get_all, sync_blocking, CacheConfig};
-use nvd_cve::client::{BlockingHttpClient, ReqwestBlockingClient};
+use nvd_cve::client::ReqwestBlockingClient;
+use nvd_cve::feed::Feed;
 
 fn main() -> AppResult<()> {
-    // Parse command-line arguments.
     let args = Args::parse();
 
-    // Fetch CVEs.
+    // Expand each CLI token into one or more feeds (years, recent, modified).
+    let mut feeds = Vec::new();
+    for token in &args.feeds {
+        feeds.extend(Feed::parse(token).map_err(|e| Error::FeedParseError(e.to_string()))?);
+    }
+
     let config = CacheConfig {
-        url: args.url.to_string(),
-        feeds: args.feeds()?,
+        feeds,
         db: args.db.unwrap_or_else(CacheConfig::default_db_path),
         show_progress: true,
         force_update: args.force_update,
     };
-    if !args.offline && !Path::new(&config.db).exists() || args.force_update {
-        let client = ReqwestBlockingClient::new(&config.url, None, None, None);
-        sync_blocking(&config, client).map_err(Error::CacheError)?;
+
+    let need_sync = !args.offline && (!Path::new(&config.db).exists() || args.force_update);
+    if need_sync {
+        let client = ReqwestBlockingClient::new(args.api_key.clone())
+            .map_err(|e| Error::CacheError(nvd_cve::cache::CacheError::Http(e)))?;
+        sync_blocking(&config, &client).map_err(Error::CacheError)?;
     }
     let cves = get_all(&config).map_err(Error::CacheError)?;
 
-    // Create an application.
     let mut app = App::new(
         cves.into_iter().map(Cve::from).collect(),
         args.theme
@@ -42,7 +48,6 @@ fn main() -> AppResult<()> {
         args.query.clone().unwrap_or_default(),
     );
 
-    // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
     let events = EventHandler::new(250);
@@ -53,11 +58,8 @@ fn main() -> AppResult<()> {
         tui.events.sender.send(Event::Search)?;
     }
 
-    // Start the main loop.
     while app.running {
-        // Render the user interface.
         tui.draw(&mut app)?;
-        // Handle events.
         match tui.events.next()? {
             Event::Key(key_event) => handle_key_events(key_event, &mut app, &tui.events.sender)?,
             Event::Mouse(mouse_event) => {
@@ -93,7 +95,6 @@ fn main() -> AppResult<()> {
         }
     }
 
-    // Exit the user interface.
     tui.exit()?;
     Ok(())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -140,7 +140,7 @@ fn render_list(app: &mut App, frame: &mut Frame<'_>, area: Rect) {
     );
 }
 
-fn highlight_search_result(value: String, app: &App) -> Line {
+fn highlight_search_result(value: String, app: &App) -> Line<'_> {
     if value.contains(app.input.value()) {
         let splits = value.split(app.input.value());
         let chunks = splits.into_iter().map(|c| Span::from(c.to_owned()));


### PR DESCRIPTION
## Why

Resolves #109 and #110. The crate behind flawz, [`nvd_cve`](https://github.com/travispaul/nvd_cve), was pinned to the retired NVD JSON 1.1 data feeds. NIST returns `HTTP 403` for those URLs since late 2023, which made the cache silently empty and the TUI show no CVEs at all — exactly the empty-list bug those two issues describe.

## What

Bumps the `nvd_cve` dependency to the new `0.3` line (which speaks the [NVD 2.0 REST API](https://nvd.nist.gov/developers/vulnerabilities)) and threads its new API surface through flawz.

### `src/cve.rs`
Rebuild the UI-facing `Cve` from `nvd_cve::cve::Cve`'s new shape (`descriptions[lang=en].value`, `references[].url`, CVSS metrics). Also surfaces `base_score`, `severity` and `status` so the TUI can show them later (not wired into the renderer yet — kept this PR focused on the API migration).

### `src/args.rs`
- Drop `--url` (the 2.0 endpoint is fixed)
- Add `--api-key` / `NVD_API_KEY` env var — without a key NVD's rate limit is 5 req / 30s, with one it's 50 / 30s (~10× faster sync). Help text links to the free API-key signup page.
- Default `--feeds` token range extended to `2025`

### `src/main.rs`
Rewired onto `nvd_cve::client::ReqwestBlockingClient::new(api_key)` (single argument) and `nvd_cve::feed::Feed::parse` to expand CLI tokens (`2024`, `2002:2024`, `recent`, `modified`).

### `src/error.rs`
`RangeArgsError` replaced by `FeedParseError(String)`, which carries the richer parser message from `nvd_cve::feed::FeedError` (handles unknown tokens, reversed ranges, etc.).

## UX notes

- Existing 1.1-format caches are auto-detected by `nvd_cve` and recreated on the first 2.0 sync. Users keep their on-disk path.
- Sync time without an API key: roughly 5 min per year due to the 5-req/30s budget. With a key: ~30s per year. The CLI now flags this in `--api-key`'s help text.

## Tests

flawz itself has no behavioural tests, so the validation lives in `nvd_cve`:

- 19 unit tests + 1 live-fixture integration test (xz backdoor `CVE-2024-3094`) — all pass
- Live smoke test from this branch: 1939 CVEs synced for `recent` in ~2 s, search returned real results across CVSS severities

## ⚠️ Blocker

This PR depends on [travispaul/nvd_cve#18](https://github.com/travispaul/nvd_cve/pull/18). To make this PR build reproducibly while that PR is open, `Cargo.toml` currently uses a git dep against my fork:

```toml
nvd_cve = { version = "0.3.0", git = "https://github.com/Aionmizu/nvd_cve", branch = "nvd-api-2.0" }
```

Once `nvd_cve 0.3.0` is published to crates.io, the line should be reverted to a plain `nvd_cve = "0.3.0"`. Happy to push that follow-up commit when the upstream lands.

Bumped flawz to `0.4.0` to reflect the breaking dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)